### PR TITLE
Bump add trailing comma version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ packages = find:
 install_requires =
     black==23.3.0
     add-trailing-comma==2.5.1
+python_requires = >=3.8
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ description = Run custom formatting
 packages = find:
 install_requires =
     black==23.3.0
-    add-trailing-comma==2.4.0
+    add-trailing-comma==2.5.1
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
In this update, add-trailing-comma updates its minimum version to Python 3.8, so this has been reflected in this PR along with the version bump.