### PR TITLE
Only write changes to files one

### DIFF
--- a/src/format.py
+++ b/src/format.py
@@ -4,49 +4,25 @@ import argparse
 from pathlib import Path
 
 from add_trailing_comma._main import _fix_src
-from black import WriteBack
+from black import format_str
 from black.mode import Mode
-from black.report import Report
 
 
 def fix_file(file, args):
-    """Updated version of add_trailing_comma function to remove logging."""
+    """Fix a single file and write the results if changed."""
     contents_text_orig = contents_text = file.read_bytes().decode()
+
+    # Remove trailing commas
+    contents_text = format_str(contents_text, mode=Mode(magic_trailing_comma=False))
+
+    # Add trailing commas
     contents_text = _fix_src(contents_text, args.min_version)
+
+    # Format with black
+    contents_text = format_str(contents_text, mode=Mode(magic_trailing_comma=True))
+
     if contents_text != contents_text_orig:
         file.write_bytes(contents_text.encode())
-
-
-class BlackFormatter:
-    """Configuration to run black."""
-
-    report = Report(check=False, diff=False, quiet=True, verbose=False)
-    write_back = WriteBack.from_configuration(check=False, diff=False, color=True)
-
-    def run(self, filenames, skip_magic_trailing_comma):
-        """Run trimmed down version of black formatting."""
-        mode = Mode(magic_trailing_comma=not skip_magic_trailing_comma)
-        if len(filenames) == 1:
-            from black import reformat_one
-
-            reformat_one(
-                src=Path(filenames[0]),
-                fast=False,
-                write_back=self.write_back,
-                mode=mode,
-                report=self.report,
-            )
-        else:
-            from black.concurrency import reformat_many
-
-            reformat_many(
-                sources=[Path(file) for file in filenames],
-                fast=False,
-                write_back=self.write_back,
-                mode=mode,
-                report=self.report,
-                workers=None,
-            )
 
 
 class TrailingCommaArgs:
@@ -58,12 +34,8 @@ class TrailingCommaArgs:
 def run_formatting(args):
     """Run formatting for specified files."""
     trailing_comma_cargs = TrailingCommaArgs()
-    black = BlackFormatter()
-    black.run(args.filenames, skip_magic_trailing_comma=True)
     for filename in args.filenames:
         fix_file(Path(filename), trailing_comma_cargs)
-
-    black.run(args.filenames, skip_magic_trailing_comma=False)
 
 
 def format_files(args):

--- a/src/format.py
+++ b/src/format.py
@@ -10,7 +10,7 @@ from black.mode import Mode
 
 def fix_file(file):
     """Fix a single file and write the results if changed."""
-    contents_text_orig = contents_text = file.read_bytes().decode()
+    contents_text_orig = contents_text = Path(file).read_bytes().decode()
 
     # Remove trailing commas
     contents_text = format_str(contents_text, mode=Mode(magic_trailing_comma=False))
@@ -22,7 +22,7 @@ def fix_file(file):
     contents_text = format_str(contents_text, mode=Mode(magic_trailing_comma=True))
 
     if contents_text != contents_text_orig:
-        file.write_bytes(contents_text.encode())
+        Path(file).write_bytes(contents_text.encode())
 
 
 def format_files(args):
@@ -39,7 +39,7 @@ def format_files(args):
             return 1
 
     for filename in args.filenames:
-        fix_file(Path(filename))
+        fix_file(filename)
 
     return 0
 

--- a/src/format.py
+++ b/src/format.py
@@ -26,6 +26,7 @@ def fix_file(file):
 
     return contents_text != contents_text_orig
 
+
 def format_files(args):
     """Format specified files."""
     if len(args.filenames) == 0:

--- a/src/format.py
+++ b/src/format.py
@@ -8,7 +8,7 @@ from black import format_str
 from black.mode import Mode
 
 
-def fix_file(file, args):
+def fix_file(file):
     """Fix a single file and write the results if changed."""
     contents_text_orig = contents_text = file.read_bytes().decode()
 
@@ -16,19 +16,13 @@ def fix_file(file, args):
     contents_text = format_str(contents_text, mode=Mode(magic_trailing_comma=False))
 
     # Add trailing commas
-    contents_text = _fix_src(contents_text, args.min_version)
+    contents_text = _fix_src(contents_text, (3, 6))
 
     # Format with black
     contents_text = format_str(contents_text, mode=Mode(magic_trailing_comma=True))
 
     if contents_text != contents_text_orig:
         file.write_bytes(contents_text.encode())
-
-
-class TrailingCommaArgs:
-    """Trailing commas arguments class."""
-
-    min_version = (3, 6)
 
 
 def format_files(args):
@@ -44,9 +38,8 @@ def format_files(args):
 
             return 1
 
-    trailing_comma_cargs = TrailingCommaArgs()
     for filename in args.filenames:
-        fix_file(Path(filename), trailing_comma_cargs)
+        fix_file(Path(filename))
 
     return 0
 

--- a/src/format.py
+++ b/src/format.py
@@ -24,6 +24,7 @@ def fix_file(file):
     if contents_text != contents_text_orig:
         Path(file).write_bytes(contents_text.encode())
 
+    return contents_text != contents_text_orig
 
 def format_files(args):
     """Format specified files."""
@@ -38,10 +39,11 @@ def format_files(args):
 
             return 1
 
+    ret = 0
     for filename in args.filenames:
-        fix_file(filename)
+        ret |= fix_file(filename)
 
-    return 0
+    return ret
 
 
 def main(argv=None):

--- a/src/format.py
+++ b/src/format.py
@@ -31,13 +31,6 @@ class TrailingCommaArgs:
     min_version = (3, 6)
 
 
-def run_formatting(args):
-    """Run formatting for specified files."""
-    trailing_comma_cargs = TrailingCommaArgs()
-    for filename in args.filenames:
-        fix_file(Path(filename), trailing_comma_cargs)
-
-
 def format_files(args):
     """Format specified files."""
     if len(args.filenames) == 0:
@@ -51,7 +44,9 @@ def format_files(args):
 
             return 1
 
-    run_formatting(args)
+    trailing_comma_cargs = TrailingCommaArgs()
+    for filename in args.filenames:
+        fix_file(Path(filename), trailing_comma_cargs)
 
     return 0
 


### PR DESCRIPTION
Before this PR, the following pseudocode was run: 

1. Format with black to remove the trailing commas and write the output
2. Run add-trailing-comma for each file and write the output
3. Format with black with magic trailing commas where appropriate and write the output

This process required a file to be written three times (once for each stage).

This update updates to the following structure:

For each file:
  1. Read the file
  2. Remove magic trailing commas
  3. Add trailing commas where appropriate
  4. Format with black
  5. Write the output

When testing locally for a small number of files, there is no performance hit (it is even faster in some cases). However, as the number of files increases, the total run time increases to approximately 50% slower for a project with ~500 files. As in most cases, a pre-commit hook will only be run on a small number of files, not a whole repo, it is hoped that this performance regression will not cause significant issues. 

In a future PR, there are also plans to implement an async IO event loop to address this performance regression for instances where multiple files are formatted, for example, in CI when running `pre-commit run --all-files`. This implementation will look to follow [black's `reformat_many` implementation](https://github.com/psf/black/blob/main/src/black/concurrency.py#L70C5-L70C18).