### PR TITLE
Process multiple files concurrently 

### DIFF
--- a/format/__init__.py
+++ b/format/__init__.py
@@ -33,15 +33,6 @@ def fix_file(file: str) -> bool:
     return contents_text != contents_text_orig
 
 
-def fix_multiple_files(files: Sequence[str]) -> int:
-    """Fix multiple files."""
-    ret = 0
-    for file in files:
-        ret |= fix_file(file)
-
-    return ret
-
-
 def main(argv: Sequence[str] | None = None) -> int:
     """Run Formatter."""
     parser = argparse.ArgumentParser()
@@ -61,6 +52,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if len(args.filenames) == 1:
         return fix_file(args.filenames[0])
+
+    from format.concurrency import fix_multiple_files
 
     return fix_multiple_files(args.filenames)
 

--- a/format/concurrency.py
+++ b/format/concurrency.py
@@ -1,0 +1,104 @@
+"""Handle formatting multiple files via multiprocessing.
+
+Based off of black.concurrency.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from black.concurrency import cancel, maybe_install_uvloop, shutdown
+from black.report import Changed, Report
+
+from format import fix_file
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def fix_multiple_files(files: Sequence[str]) -> int:
+    """Fix multiple files.
+
+    Similar to black.concurrency.reformat_many updated to use fix_file function.
+    """
+    maybe_install_uvloop()
+
+    workers = os.cpu_count() or 1
+
+    executor: Executor
+    try:
+        executor = ProcessPoolExecutor(max_workers=workers)
+    except (ImportError, NotImplementedError, OSError):
+        # We arrive here if the underlying system does not support multi-processing
+        # like in AWS Lambda or Termux, in which case we gracefully fallback to
+        # a ThreadPoolExecutor with just a single worker (more workers would not do us
+        # any good due to the Global Interpreter Lock)
+        executor = ThreadPoolExecutor(max_workers=1)
+
+    report = Report()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(
+            schedule_formatting(
+                files=set(files),
+                report=report,
+                loop=loop,
+                executor=executor,
+            ),
+        )
+    finally:
+        try:
+            shutdown(loop)
+        finally:
+            asyncio.set_event_loop(None)
+
+        if executor is not None:
+            executor.shutdown()
+
+    return report.return_code
+
+
+async def schedule_formatting(
+    files: set[str],
+    report: Report,
+    loop: asyncio.AbstractEventLoop,
+    executor: Executor,
+) -> None:
+    """Run formatting of `files` in parallel using the provided `executor`.
+
+    (Use ProcessPoolExecutors for actual parallelism.)
+
+    Similar to black.concurrency.schedule_formatting updated to use fix_file function.
+    """
+    cancelled = []
+    tasks = {
+        asyncio.ensure_future(loop.run_in_executor(executor, fix_file, src)): src
+        for src in sorted(files)
+    }
+    pending = tasks.keys()
+    try:
+        loop.add_signal_handler(signal.SIGINT, cancel, pending)
+        loop.add_signal_handler(signal.SIGTERM, cancel, pending)
+    except NotImplementedError:
+        # There are no good alternatives for these on Windows.
+        pass
+
+    while pending:
+        done, _ = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+        for task in done:
+            src = tasks.pop(task)
+            if task.cancelled():
+                cancelled.append(task)
+            elif task.exception():
+                report.failed(Path(src), str(task.exception()))
+            else:
+                report.done(Path(src), Changed.YES if task.result() else Changed.NO)
+
+    if cancelled:
+        await asyncio.gather(*cancelled, return_exceptions=True)

--- a/src/format.py
+++ b/src/format.py
@@ -50,6 +50,10 @@ def main(argv: Sequence[str] | None = None) -> int:
 
             return 1
 
+    if len(args.filenames) == 1:
+        return fix_file(args.filenames[0])
+
+    print("Reformatting multiple files")
     ret = 0
     for filename in args.filenames:
         ret |= fix_file(filename)

--- a/src/format.py
+++ b/src/format.py
@@ -33,8 +33,12 @@ def fix_file(file: str) -> bool:
     return contents_text != contents_text_orig
 
 
-def format_files(args: argparse.Namespace) -> int:
-    """Format specified files."""
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run Formatter."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("filenames", nargs="*")
+    args = parser.parse_args(argv)
+
     if len(args.filenames) == 0:
         print("Please pass files to be formatted")
 
@@ -51,15 +55,6 @@ def format_files(args: argparse.Namespace) -> int:
         ret |= fix_file(filename)
 
     return ret
-
-
-def main(argv: Sequence[str] | None = None) -> int:
-    """Run Formatter."""
-    parser = argparse.ArgumentParser()
-    parser.add_argument("filenames", nargs="*")
-    args = parser.parse_args(argv)
-
-    return format_files(args)
 
 
 if __name__ == "__main__":

--- a/src/format.py
+++ b/src/format.py
@@ -33,6 +33,15 @@ def fix_file(file: str) -> bool:
     return contents_text != contents_text_orig
 
 
+def fix_multiple_files(files: Sequence[str]) -> int:
+    """Fix multiple files."""
+    ret = 0
+    for file in files:
+        ret |= fix_file(file)
+
+    return ret
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run Formatter."""
     parser = argparse.ArgumentParser()
@@ -53,12 +62,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if len(args.filenames) == 1:
         return fix_file(args.filenames[0])
 
-    print("Reformatting multiple files")
-    ret = 0
-    for filename in args.filenames:
-        ret |= fix_file(filename)
-
-    return ret
+    return fix_multiple_files(args.filenames)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Taking inspiration from `black.concurrency`, this PR allows `format` to make use of async to process files.

## Test Case
Testing on the CORE POWER web app codebase. Running `pre-commit try-repo ../format --verbose --all-files`

### Running on the current main branch
```
[INFO] Initializing environment for ../format.
===============================================================================
Using config:
===============================================================================
repos:
-   repo: ../format
    rev: e642079052d84dde6cd7d5377f651504a33717f6
    hooks:
    -   id: format
===============================================================================
[INFO] Installing environment for ../format.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
format...................................................................Passed
- hook id: format
- duration: 19.09s
```

### Running on this branch
```
[INFO] Initializing environment for ../format.
===============================================================================
Using config:
===============================================================================
repos:
-   repo: ../format
    rev: 74b2571eff758db937dbb59e80bef7b3d8414131
    hooks:
    -   id: format
===============================================================================
[INFO] Installing environment for ../format.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
format...................................................................Passed
- hook id: format
- duration: 4.95s
```

Almost 4 times faster